### PR TITLE
disable bt hal hwservicemanager lazy start as well

### DIFF
--- a/bluetooth/android.hardware.bluetooth@1.1-service.vbt.rc
+++ b/bluetooth/android.hardware.bluetooth@1.1-service.vbt.rc
@@ -1,6 +1,4 @@
 service vendor.bluetooth-1-1 /vendor/bin/hw/android.hardware.bluetooth@1.1-service.vbt
-    interface android.hardware.bluetooth@1.1::IBluetoothHci default
-    interface android.hardware.bluetooth@1.0::IBluetoothHci default
     class hal
     capabilities BLOCK_SUSPEND NET_ADMIN SYS_NICE
     user bluetooth


### PR DESCRIPTION
it is possible for hwservicemanager to lazy start the service when framework uses those two interfaces

disable that as well for the new btlinux switch in init.sh